### PR TITLE
fix bug in the random agent example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Example random agent script:
 ```
 import numpy as np
 from coinrun import setup_utils, make
-import gym.spaces
 
 setup_utils.setup_and_load(use_cmd_line_args=False)
 env = make('standard', num_envs=16)

--- a/coinrun/coinrunenv.py
+++ b/coinrun/coinrunenv.py
@@ -11,6 +11,7 @@ import sys
 from ctypes import c_int, c_char_p, c_float, c_bool
 
 import gym
+import gym.spaces
 import numpy as np
 import numpy.ctypeslib as npct
 from baselines.common.vec_env import VecEnv
@@ -208,7 +209,7 @@ class CoinRunVecEnv(VecEnv):
 
         if Config.USE_BLACK_WHITE:
             obs_frames = np.mean(obs_frames, axis=-1).astype(np.uint8)[...,None]
-        
+
         return obs_frames, self.buf_rew, self.buf_done, self.dummy_info
 
 def make(env_id, num_envs, **kwargs):


### PR DESCRIPTION
When I ran the original script I got 

```
Logging to /tmp/openai-2018-12-14-17-36-08-425220
make: Entering directory '/home/act65/repos/coinrun/coinrun'
make: Nothing to be done for 'all'.
make: Leaving directory '/home/act65/repos/coinrun/coinrun'
Traceback (most recent call last):
  File "main.py", line 6, in <module>
    env = make('standard', num_envs=16)
  File "/home/act65/repos/coinrun/coinrun/coinrunenv.py", line 216, in make
    return CoinRunVecEnv(env_id, num_envs, **kwargs)
  File "/home/act65/repos/coinrun/coinrun/coinrunenv.py", line 156, in __init__
    obs_space = gym.spaces.Box(0, 255, shape=[self.RES_H, self.RES_W, num_channels], dtype=np.uint8)
AttributeError: module 'gym' has no attribute 'spaces'
```

Adding `import gym.spaces` fixes the bug ([see issue here](https://github.com/openai/gym/issues/376)). Although maybe it should be imported elsewhere!?