### PR TITLE
Rename shutdown() to coinrun_shutdown().

### DIFF
--- a/coinrun/coinrun.cpp
+++ b/coinrun/coinrun.cpp
@@ -1966,7 +1966,7 @@ void vec_wait(
   }
 }
 
-void shutdown()
+void coinrun_shutdown()
 {
   shutdown_flag = true;
   while (!all_threads.empty()) {
@@ -2228,7 +2228,7 @@ extern "C" void test_main_loop()
   delete app;
 
   vec_close(handle);
-  shutdown();
+  coinrun_shutdown();
 }
 
 #include ".generated/coinrun.moc"

--- a/coinrun/coinrunenv.py
+++ b/coinrun/coinrunenv.py
@@ -123,7 +123,7 @@ def shutdown():
     global already_inited
     if not already_inited:
         return
-    lib.shutdown()
+    lib.coinrun_shutdown()
 
 class CoinRunVecEnv(VecEnv):
     """


### PR DESCRIPTION
This is to prevent conflicts with the POSIX socket shutdown() function.