### PR TITLE
fix accessing potential 0 elements array when use_aux is False

### DIFF
--- a/coinrun/wrappers.py
+++ b/coinrun/wrappers.py
@@ -77,7 +77,7 @@ class EpisodeRewardWrapper(gym.Wrapper):
                         is_game_over = infos[i]['ale.lives'] == 0
 
                         if is_game_over:
-                            game_over_rew = self.long_aux_rewards[i,0]
+                            game_over_rew = self.long_aux_rewards[i,0] if use_aux else 0
                             self.long_aux_rewards[i,:] = 0
 
                         aux_dict['game_over_rew'] = game_over_rew


### PR DESCRIPTION
when game is over, game_over_rew can access long_aux_rewards which can be potentially in shape zero at axis 1 when use_aux is False. We can first look at whether use_aux is True and then decide to access long_aux_rewards or set game_over_rew to simply zero.