### PR TITLE
Fix issue with deconstructing the high-resolution environment

### DIFF
--- a/coinrun/coinrun.cpp
+++ b/coinrun/coinrun.cpp
@@ -1156,7 +1156,7 @@ struct Agent {
 
   ~Agent() {
     if (render_hires_buf) {
-      delete render_hires_buf;
+      delete[] render_hires_buf;
       render_hires_buf = 0;
     }
     if (monitor_csv) {


### PR DESCRIPTION
…on observation buffers. This fixes an error with setting up the high-resolution version (`is_high_res=True`) of the environment.