### PR TITLE
Handle "make" for paths with spaces

### DIFF
--- a/coinrun/coinrunenv.py
+++ b/coinrun/coinrunenv.py
@@ -38,7 +38,7 @@ def build():
     if lrank == 0:
         dirname = os.path.dirname(__file__)
         if len(dirname):
-            make_cmd = "QT_SELECT=5 make -C %s" % dirname
+            make_cmd = "QT_SELECT=5 make -C \"%s\"" % dirname
         else:
             make_cmd = "QT_SELECT=5 make"
 


### PR DESCRIPTION
The path stored in `dirname` contained a space for my install. This was causing the `os.system` "make" command to fail. Adding quotes to the command fixes it as far as I can tell (running `macOS 11.1`, `Python 3.6.12`, `zsh 5.12`).